### PR TITLE
handle read err to break the loop

### DIFF
--- a/tool/differ.go
+++ b/tool/differ.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-// clearString replace all white chars
+// clearString is to replace all white chars
 func clearString(str string) string {
 	trimStr := strings.ReplaceAll(str, " ", "")
 	trimStr = strings.ReplaceAll(trimStr, "\t", "")
@@ -16,12 +16,13 @@ func clearString(str string) string {
 	return trimStr
 }
 
-// clearEnter replace all '\r' chars
+// clearEnter is to replace all '\r' chars
 func clearEnter(str string) string {
 	trimStr := strings.ReplaceAll(str, "\r", "")
 	return trimStr
 }
 
+// getFileContent is to read the file content line by line and do some replaces for each lines
 func getFileContent(fileName string, diffIgnoreHead bool, strictMode bool) (string, error) {
 	src, err := os.Open(fileName)
 	if err != nil {
@@ -57,7 +58,7 @@ func getFileContent(fileName string, diffIgnoreHead bool, strictMode bool) (stri
 				}
 			}
 		}
-		if err == io.EOF {
+		if err != nil {
 			break
 		}
 	}

--- a/tool/differ_test.go
+++ b/tool/differ_test.go
@@ -108,7 +108,7 @@ func TestDiffOutFunc(t *testing.T) {
 			shouldSame: true,
 		},
 		{
-			desc:       "(L)The size of user.out is zero",
+			desc:       "(L)The size of file is large than 65535 bytes",
 			userOut:    "userv7.out",
 			dataOut:    "datav7.out",
 			ignoreHead: false,


### PR DESCRIPTION
As mentioned by @plter, if there were some other type errors, we couldn't go out of the for loop when reading the file line by line.

Signed-off-by: lifubang <lifubang@acmcoder.com>